### PR TITLE
add remove btn / apply MimeType filter / review UI

### DIFF
--- a/controls/fileselect-control.php
+++ b/controls/fileselect-control.php
@@ -64,17 +64,64 @@ class FileSelect_Control extends \Elementor\Base_Data_Control {
 	public function content_template() {
 		$control_uid = $this->get_control_uid();
 		?>
-		<div class="elementor-control-field">
-			<label for="<?php echo esc_attr( $control_uid ); ?>" class="elementor-control-title">{{{ data.label }}}</label>
-			<div class="elementor-control-input-wrapper">
-				<a href="#" class="tnc-select-file elementor-button elementor-button-success" style="padding: 10px 15px; display: block;text-align: center;" id="select-file-<?php echo esc_attr( $control_uid ); ?>" ><?php echo esc_html__( "Choose / Upload File", 'file-select-control-elementor' ); ?></a> <br />
+			<div class="elementor-control-field">
+				<label for="<?php echo esc_attr( $control_uid ); ?>" class="elementor-control-title" style="display:block">
+					{{{ data.label }}}
+				</label>
+				
+				<# if ( !!data.controlValue ) { #>
+					<small style="display:block; width:100%; padding-top:7px;">
+						{{{ data.controlValue }}}
+					</small>
+				<# } #>
+				
+				<div class="elementor-control-input-wrapper"
+					style="display:flex; margin-right:-10px; width:calc( 100% + 10px );">
+					<div style="flex-grow:1;">
+						<a href="#"
+							class="tnc-select-file elementor-button elementor-button-success"
+							style="padding:10px 15px; text-align:center; display:block; margin-right:10px;"
+							id="select-file-<?php echo esc_attr( $control_uid ); ?>">
+							<# if ( !data.controlValue ) { #>
+								<?php echo __("Select"); ?>
+							<# } #>
+							<# if ( !!data.controlValue ) { #>
+								<?php echo __("Edit"); ?>
+							<# } #>
+						</a>
+					</div>
 
-				<input type="text" class="tnc-selected-fle-url" id="<?php echo esc_attr( $control_uid ); ?>" data-setting="{{ data.name }}" placeholder="{{ data.placeholder }}">
+					<# if ( !!data.controlValue ) { #>
+						<div style="flex-shrink:1;">
+							<a href="{{{ data.controlValue }}}" target="_blank"
+								class="tnc-view-file elementor-button elementor-button-warning"
+								style="padding:10px 15px; text-align:center; margin-right:10px;"
+								id="select-file-<?php echo esc_attr( $control_uid ); ?>-link"
+								title="<?php echo __("View"); ?>">
+								<i class="eicon-link" style="margin-right:0;"></i>
+							</a>
+							<a href="#"
+								class="tnc-remove-file elementor-button elementor-button-danger"
+								style="padding:10px 15px; text-align:center; margin-right:10px;"
+								id="select-file-<?php echo esc_attr( $control_uid ); ?>-remove"
+								title="<?php echo __("Remove"); ?>">
+								<i class="eicon-trash" style="margin-right:0;"></i>
+							</a>
+						</div>
+					<# } #>
+					
+					<input type="hidden"
+						class="tnc-selected-fle-url"
+						id="<?php echo esc_attr( $control_uid ); ?>"
+						data-setting="{{ data.name }}"
+						placeholder="{{ data.placeholder }}">
+				</div>
 			</div>
-		</div>
-		<# if ( data.description ) { #>
-		<div class="elementor-control-field-description">{{{ data.description }}}</div>
-		<# } #>
+			<# if ( data.description ) { #>
+				<div class="elementor-control-field-description">
+					{{{ data.description }}}
+				</div>
+			<# } #>
 		<?php
 	}
 }

--- a/controls/js/fileselect-control.js
+++ b/controls/js/fileselect-control.js
@@ -1,25 +1,35 @@
-var fileselectItemView = elementor.modules.controls.BaseData.extend({
-	
-    onReady: function () {
+elementor.addControlView('file-select', elementor.modules.controls.BaseData.extend({
 
-    	var file_input_id = this.$el.find( '.tnc-selected-fle-url' ).attr('id');
+	onReady: function () {
+		
+		var that = this,
+			$el = this.$el,
+			wpMediaOptions = { multiple: false },
+			inputHidden = $el.find('.tnc-selected-fle-url');
 
-    	this.$el.find( '.tnc-select-file' ).click( function() {
-	   	  	var tnc_file_uploader = wp.media({
-	            title: 'Upload File',
-	            button: {
-	                text: 'Get Link'
-	            },
-	            multiple: false
-	        })
-	        .on('select', function() {
-	            var attachment = tnc_file_uploader.state().get('selection').first().toJSON();
-	            jQuery( "#" + file_input_id ).val( attachment.url );
-	            jQuery( "#" + file_input_id ).trigger( "input" );
-	        })
-	        .open();
-	   	} );
-	},
-});
+		if (!!this.model.attributes.library_type) {
+			wpMediaOptions.library = {
+				orderby: "date",
+				query: true,
+				post_mime_type: [ this.model.attributes.library_type ]
+			};
+		}
+		
+		$el.find('.tnc-select-file').click(function (e) {
+			var tnc_file_uploader = wp.media(wpMediaOptions)
+				.on('select', function () {
+					var attachment = tnc_file_uploader.state().get('selection').first().toJSON();
+					inputHidden.val(attachment.url).trigger('input');
+					that.render();
+				})
+				.open();
+		});
 
-elementor.addControlView('file-select', fileselectItemView);
+		$el.find('.tnc-remove-file').click(function (e) {
+			e.preventDefault();
+			inputHidden.removeAttr('value').trigger('input');
+			that.render();
+		});
+	}
+
+}));


### PR DESCRIPTION
I've needed your plugin for one of my project, but I needed the user to be able to remove the selected file.

By the way I've done some improvements :
- the `input[type=text]` has ugly and isn't show anymore
- the file URL appear before buttons
- I'va added an `a[target=_blank]` to acces the file
- I've added a remove button
- `wp.media` display only correct file (mime type)

Next step will be to save the attachment ID instead of the URL.