### PR TITLE
Dynamic library title and library button text

### DIFF
--- a/controls/js/fileselect-control.js
+++ b/controls/js/fileselect-control.js
@@ -14,6 +14,16 @@ elementor.addControlView('file-select', elementor.modules.controls.BaseData.exte
 				post_mime_type: [ this.model.attributes.library_type ]
 			};
 		}
+
+		if (!!this.model.attributes.library_title) {
+			wpMediaOptions.title = this.model.attributes.library_title;
+		}
+
+		if (!!this.model.attributes.library_button_text) {
+			wpMediaOptions.button = {
+				text: this.model.attributes.library_button_text
+			};
+		}
 		
 		$el.find('.tnc-select-file').click(function (e) {
 			var tnc_file_uploader = wp.media(wpMediaOptions)


### PR DESCRIPTION
Developers now can define the media library title and the select button text from their control.

Example: 

```php
$this->add_control(
    'json_file',
    [
        'label' => esc_html__( 'Select File', 'domain' ),
        'type'  => 'file-select',
        'library_type' => 'application/json',
        'library_title' => __('Select JSON File', 'domain'),
        'library_button_text' => __('Select', 'domain'),
    ]
);
```